### PR TITLE
add float and time.time to marshaller

### DIFF
--- a/e2etest/marshal_test.go
+++ b/e2etest/marshal_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DRK-Blutspende-BaWueHe/go-astm/lib/standardlis2a2"
 	"github.com/DRK-Blutspende-BaWueHe/go-astm/lis2a2"
@@ -38,16 +39,16 @@ func TestSimpleMarshal(t *testing.T) {
 
 	lines, err := lis2a2.Marshal(msg, lis2a2.EncodingASCII, lis2a2.TimezoneEuropeBerlin, lis2a2.ShortNotation)
 
-	/*	// output on screen
-		for _, line := range lines {
-			linestr := string(line)
-			fmt.Println(linestr)
-			} */
+	for _, line := range lines {
+		linestr := string(line)
+		fmt.Println(linestr)
+	}
+
 	assert.Nil(t, err)
 
-	assert.Equal(t, string(lines[0]), "H|\\^&||password|test||||||||0.1.0|")
-	assert.Equal(t, string(lines[1]), "?|1|first-arr1^^third-arr1\\first-arr2^second-arr2||")
-	assert.Equal(t, string(lines[2]), "L|1||")
+	assert.Equal(t, "H|\\^&||password|test||||||||0.1.0|", string(lines[0]))
+	assert.Equal(t, "?|1|first-arr1^^third-arr1\\first-arr2^second-arr2||", string(lines[1]))
+	assert.Equal(t, "L|1||", string(lines[2]))
 }
 
 type ArrayMessageMarshal struct {
@@ -75,10 +76,10 @@ func TestGenverateSequence(t *testing.T) {
 		fmt.Println(linestr)
 	}
 
-	assert.Equal(t, string(lines[0]), "H|\\^&||||||||||||")
-	assert.Equal(t, string(lines[1]), "P|1||||Firstus'^Firstie|||||||||||||||||||||||||||||")
-	assert.Equal(t, string(lines[2]), "P|2||||Secundus'^Secundie|||||||||||||||||||||||||||||")
-	assert.Equal(t, string(lines[3]), "L|1||")
+	assert.Equal(t, "H|\\^&||||||||||||", string(lines[0]))
+	assert.Equal(t, "P|1||||Firstus'^Firstie|||||||||||||||||||||||||||||", string(lines[1]))
+	assert.Equal(t, "P|2||||Secundus'^Secundie|||||||||||||||||||||||||||||", string(lines[2]))
+	assert.Equal(t, "L|1||", string(lines[3]))
 }
 
 type PatientResult struct {
@@ -123,11 +124,36 @@ func TestNestedStruct(t *testing.T) {
 		fmt.Println(linestr)
 	}
 
-	assert.Equal(t, string(lines[0]), "H|\\^&||||||||||||")
-	assert.Equal(t, string(lines[1]), "P|1||||Norris^Chuck||||||||||||||||||||||Binaries|||||||")
-	assert.Equal(t, string(lines[2]), "R|1|^^^^SulfurBloodCount^^|^^100|%|||||^||")
-	assert.Equal(t, string(lines[3]), "R|2|^^^^Catblood^^|^^>100000|U/l|||||^||")
-	assert.Equal(t, string(lines[4]), "P|1||||Cartman^Eric||||||||||||||||||||||None|||||||")
-	assert.Equal(t, string(lines[5]), "R|1|^^^^Fungenes^^|^^present|none|||||^||")
-	assert.Equal(t, string(lines[6]), "L|1||")
+	assert.Equal(t, "H|\\^&||||||||||||", string(lines[0]))
+	assert.Equal(t, "P|1||||Norris^Chuck||||||||||||||||||||||Binaries|||||||", string(lines[1]))
+	assert.Equal(t, "R|1|^^^^SulfurBloodCount^^|^^100|%|||||^||", string(lines[2]))
+	assert.Equal(t, "R|2|^^^^Catblood^^|^^>100000|U/l|||||^||", string(lines[3]))
+	assert.Equal(t, "P|1||||Cartman^Eric||||||||||||||||||||||None|||||||", string(lines[4]))
+	assert.Equal(t, "R|1|^^^^Fungenes^^|^^present|none|||||^||", string(lines[5]))
+	assert.Equal(t, "L|1||", string(lines[6]))
+}
+
+type TimeTestMessageMarshal struct {
+	Header standardlis2a2.Header `astm:"H"`
+}
+
+/*
+	Test provides current time as UTC and expects the converter to stream as Belrin-Time
+*/
+func TestTimeLocalization(t *testing.T) {
+
+	var msg TimeTestMessageMarshal
+
+	europeBerlin, err := time.LoadLocation("Europe/Berlin")
+	assert.Nil(t, err)
+
+	testTime := time.Now()
+	timeInBerlin := time.Now().In(europeBerlin)
+
+	msg.Header.DateAndTime = testTime.UTC()
+
+	lines, err := lis2a2.Marshal(msg, lis2a2.EncodingASCII, lis2a2.TimezoneEuropeBerlin, lis2a2.ShortNotation)
+	assert.Nil(t, err)
+
+	assert.Equal(t, fmt.Sprintf("H|\\^&||||||||||||%s|", timeInBerlin.Format("20060102150405")), string(lines[0]))
 }

--- a/lis2a2/constants.go
+++ b/lis2a2/constants.go
@@ -1,5 +1,13 @@
 package lis2a2
 
+const (
+	ANNOTATION_DELIMITER = "delimiter" // annotation that triggers the delimiters in the scanner to be reset
+	ANNOTATION_REQUIRED  = "require"   // field-annotation: by default all fields are optinal
+	ANNOTATION_OPTIONAL  = "optional"  // record-annotation: by default all records are mandatory
+	ANNOTATION_SEQUENCE  = "sequence"  // indicating that a sequence number should be generated (output only)
+	ANNOTATION_LONGDATE  = "longdate"
+)
+
 type Encoding int
 
 const EncodingUTF8 Encoding = 1

--- a/lis2a2/marshal.go
+++ b/lis2a2/marshal.go
@@ -84,7 +84,7 @@ func iterateStructFieldsAndBuildOutput(message interface{}, depth int, enc Encod
 			if currentRecord.Kind() == reflect.Slice { // it is an annotated slice
 				if !currentRecord.IsNil() {
 					for x := 0; x < currentRecord.Len(); x++ {
-						outs, err := processOneRecord(recordType, currentRecord.Index(x), x+1, repeatDelimiter, componentDelimiter, escapeDelimiter) // fmt.Println(outp)
+						outs, err := processOneRecord(recordType, currentRecord.Index(x), x+1, location, repeatDelimiter, componentDelimiter, escapeDelimiter) // fmt.Println(outp)
 						if err != nil {
 							return nil, err
 						}
@@ -92,7 +92,7 @@ func iterateStructFieldsAndBuildOutput(message interface{}, depth int, enc Encod
 					}
 				}
 			} else {
-				outs, err := processOneRecord(recordType, currentRecord, 1, repeatDelimiter, componentDelimiter, escapeDelimiter) // fmt.Println(outp)
+				outs, err := processOneRecord(recordType, currentRecord, 1, location, repeatDelimiter, componentDelimiter, escapeDelimiter) // fmt.Println(outp)
 				if err != nil {
 					return nil, err
 				}
@@ -105,7 +105,7 @@ func iterateStructFieldsAndBuildOutput(message interface{}, depth int, enc Encod
 	return buffer, nil
 }
 
-func processOneRecord(recordType string, currentRecord reflect.Value, generatedSequenceNumber int, repeatDelimiter, componentDelimiter, escapeDelimiter *string) (string, error) {
+func processOneRecord(recordType string, currentRecord reflect.Value, generatedSequenceNumber int, location *time.Location, repeatDelimiter, componentDelimiter, escapeDelimiter *string) (string, error) {
 
 	fieldList := make(OutputRecords, 0)
 
@@ -146,11 +146,26 @@ func processOneRecord(recordType string, currentRecord reflect.Value, generatedS
 			}
 
 			fieldList = addASTMFieldToList(fieldList, fieldIdx, repeatIdx, componentIdx, value)
-		case "float32":
-		case "float64":
+		case "float32", "float64":
+			//TODO: Add annotation for amount of decimals
+			value := fmt.Sprintf("%.3", field.Float())
+			fieldList = addASTMFieldToList(fieldList, fieldIdx, repeatIdx, componentIdx, value)
 		case "Time":
-			//t := time.Time(field.Interface())
-			//fmt.Println("Time = ", t)
+			time := field.Interface().(time.Time)
+
+			if !time.IsZero() {
+
+				fmt.Println("Time = ", time)
+
+				if sliceContainsString(fieldAstmTagsList, ANNOTATION_LONGDATE) {
+					value := time.In(location).Format("20060102150405")
+					fieldList = addASTMFieldToList(fieldList, fieldIdx, repeatIdx, componentIdx, value)
+				} else { // short date
+					value := time.In(location).Format("20060102")
+					fieldList = addASTMFieldToList(fieldList, fieldIdx, repeatIdx, componentIdx, value)
+				}
+			}
+
 		default:
 			return "", errors.New(fmt.Sprintf("Invalid field type '%s' in struct '%s', input not processed", field.Type().Name(), currentRecord.Type().Name()))
 		}

--- a/lis2a2/unmarshal.go
+++ b/lis2a2/unmarshal.go
@@ -86,11 +86,6 @@ const (
 	OK         RETV = 1
 	UNEXPECTED RETV = 2 // an exit that wont abort processing. used for skipping optional records
 	ERROR      RETV = 3 // a definite error that stops the process
-
-	ANNOTATION_DELIMITER = "delimiter" // annotation that triggers the delimiters in the scanner to be reset
-	ANNOTATION_REQUIRED  = "require"   // field-annotation: by default all fields are optinal
-	ANNOTATION_OPTIONAL  = "optional"  // record-annotation: by default all records are mandatory
-	ANNOTATION_SEQUENCE  = "sequence"  // indicating that a sequence number should be generated (output only)
 )
 
 var (


### PR DESCRIPTION
- New: Marshaller can now encode date-times; introduced "longdate" annotation
- Fix: unit tests had switched "expected" and "actual parameters"
- New: float32 and float64 are now searialized