### PR TITLE
fix: identitfy now recognizes multiple orderrecord

### DIFF
--- a/lis2a2/constants.go
+++ b/lis2a2/constants.go
@@ -29,11 +29,13 @@ const TimezoneEuropeLondon Timezone = "Europe/London"
 
 type LineBreak int
 
-const CR LineBreak = 0x13
-const LF LineBreak = 0x10
-const CRLF LineBreak = 0x1310
+const CR LineBreak = 0x0D
+const LF LineBreak = 0x0A
+const CRLF LineBreak = 0x0D0A
 
-/* Notation defines how the output format is build
+/*
+	Notation defines how the output format is build
+
 ShortNotation will skip all delimiters to the right of the last value
 StandardNotation will always produce as many delimiters as there are values in the export-format
 */

--- a/lis2a2/identify.go
+++ b/lis2a2/identify.go
@@ -53,6 +53,7 @@ func IdentifyMessage(messageEncoded []byte, enc Encoding) (MessageType, error) {
 	expressionQuery := "^(HQ+)+L?$"
 	expressionOrder := "^(H(PC?OC?)+)+L?$"
 	expressionOrderAndResult := "^(H(PC?OC?(RC?)+)+)+L?$"
+	expressionManyOrderAndResult := "^(H(PC?(OC?(RC?)+)*)+)L?$"
 
 	if match, _ := regexp.MatchString(expressionQuery, genome); match {
 		return MessageTypeQuery, nil
@@ -63,6 +64,10 @@ func IdentifyMessage(messageEncoded []byte, enc Encoding) (MessageType, error) {
 	}
 
 	if match, _ := regexp.MatchString(expressionOrderAndResult, genome); match {
+		return MessageTypeOrdersAndResults, nil
+	}
+
+	if match, _ := regexp.MatchString(expressionManyOrderAndResult, genome); match {
 		return MessageTypeOrdersAndResults, nil
 	}
 

--- a/lis2a2/indentity_test.go
+++ b/lis2a2/indentity_test.go
@@ -134,3 +134,33 @@ L|1|N
 
 	assert.Equal(t, MessageTypeQuery, messageType)
 }
+
+// -----------------------------------------------------------------------------------
+// The bug was that this Transmission contains one "P" and then mutlitple orders
+// Default Multi Message Was not processing those corerctly
+// -----------------------------------------------------------------------------------
+func TestIdentifyHPORCOROCOROC(t *testing.T) {
+	data := ""
+
+	data = data + "H|\\^&|||Bio-Rad|IH v5.1||||||||20230805142035\n"
+	data = data + "P|1||AA5E2ACC29||^|||||||||||||||||||||||||||^\n"
+	data = data + "O|1||AA5E2ACC29^^^\\^^^|F\n"
+	data = data + "R|1|^^^AntiA^MO01A^Blutgruppe: ABO/D  (5048)^|\n"
+	data = data + "C|1|ID-Diluent 2^^05761.04.41^20250228\\^^^|\n"
+	data = data + "R|2|^^^AntiB^MO01A^Blutgruppe: ABO/D  (5048)^|\n"
+	data = data + "O|2||AA5E2ACC29^^^\\^^^|^^^MO10^^33619^|\n"
+	data = data + "R|1|^^^AntiA^MO10^Blutgruppe Best�tigung: A,B,D (5005)^|\n"
+	data = data + "C|1|ID-Diluent 2^^05761.04.41^20250228\\^^^|\n"
+	data = data + "R|2|^^^AntiB^MO10^Blutgruppe Best�tigung: A,B,D (5005)^|\n"
+	data = data + "C|1|ID-Diluent 2^^05761.04.41^20250228\\^^^|\n"
+	data = data + "O|3||AA5E2ACC29^^^\\^^^|^^^PR07C^^33619^|\n"
+	data = data + "R|1|^^^cellA1^PR07C^Serumgegenprobe: A1,B,O (5052)^|\n"
+	data = data + "C|1|ID-DiaCell A1^^06012.49.1^20230821\\^^^|\n"
+	data = data + "L|1|N\n"
+
+	messageType, err := IdentifyMessage([]byte(data), EncodingUTF8)
+	assert.Nil(t, err)
+
+	assert.Equal(t, MessageTypeOrdersAndResults, messageType)
+
+}


### PR DESCRIPTION
Orders with a genome of HPORCORCL were not recognized as beeing results