### PR TITLE
qualified error on nil input unmarshal

### DIFF
--- a/e2etest/unmarshal_test.go
+++ b/e2etest/unmarshal_test.go
@@ -576,3 +576,13 @@ func TestMultipleMessagesInOne(t *testing.T) {
 	assert.Equal(t, "12,5", message.Messages[0].OrderResults[0].CommentedResult[0].Result.DataMeasurementValue)
 	assert.Equal(t, "99,66", message.Messages[1].OrderResults[0].CommentedResult[0].Result.DataMeasurementValue)
 }
+
+func TestNullValuesShouldGiveQualifiedError(t *testing.T) {
+
+	var message standardlis2a2.DefaultMultiMessage
+	err := lis2a2.Unmarshal(nil /*giving null as input*/, &message,
+		lis2a2.EncodingUTF8, lis2a2.TimezoneEuropeBerlin)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "message has nil value - aborting", err.Error())
+}

--- a/lis2a2/unmarshal.go
+++ b/lis2a2/unmarshal.go
@@ -17,6 +17,10 @@ const MAX_MESSAGE_COUNT = 44
 const MAX_DEPTH = 44
 
 func Unmarshal(messageData []byte, targetStruct interface{}, enc Encoding, tz Timezone) error {
+
+	if messageData == nil {
+		return fmt.Errorf("message has nil value - aborting")
+	}
 	var (
 		messageBytes []byte
 		err          error

--- a/lis2a2/unmarshal.go
+++ b/lis2a2/unmarshal.go
@@ -18,7 +18,7 @@ const MAX_DEPTH = 44
 
 func Unmarshal(messageData []byte, targetStruct interface{}, enc Encoding, tz Timezone) error {
 
-	if messageData == nil {
+	if len(messageData) == 0 {
 		return fmt.Errorf("message has nil value - aborting")
 	}
 	var (


### PR DESCRIPTION
When preseting a nil input there used to be a panic and a stacktrace. Now there is an error-message for that....